### PR TITLE
Add per-directory READMEs and correct AISA encoder-version note

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,5 +49,9 @@ SDK（https://bitmovin.com/docs/encoding/sdks) も提供されています。本
 - **drm**: DRM 出力のエンコードを行うためのサンプルです。
 - **keyframes**: KeyFrames をAPIで指定し、その部分でセグメントをカットするエンコードを行うためのサンプルです。
 - **ai-scene-analysis**: AI Scene Analysis（AI によるシーン解析）を有効にしたエンコードを行うためのサンプルです。
+- **audio-only**: 音声のみ (AAC) のエンコードを行うためのサンプルです。
+- **fixed-bitrate**: 固定ビットレートの ABR エンコード（StreamCondition / サムネイル生成 / SFTP 出力などのバリエーションを含む）を行うためのサンプルです。
+- **webvtt**: WebVTT 字幕付き HLS エンコードを行うためのサンプルです。
+- **filters/deinterlace**: Deinterlace（インターレース解除）フィルターを適用したエンコードを行うためのサンプルです。
 
 なお、本リポジトリは Bitmovin 公式のサンプル実装の日本語版を提供するものではございません。一実装例として参照ください。

--- a/ai-scene-analysis/README.md
+++ b/ai-scene-analysis/README.md
@@ -18,13 +18,13 @@
     - **asset description**: 動画のシーンを記述した JSON ファイルを出力先に生成します（`ai/` 配下）。
     - **automatic ad placement**: 検出した全シーン境界に対して、マニフェストへ SCTE cue tag を挿入します。
     - **output language codes**: AI が生成する記述の言語を指定します。`en` は既定で生成されるため、本サンプルでは追加で `ja`, `ko` を指定しています。
-  - AI Scene Analysis は現時点で **BETA エンコーダー**が必要です。サンプル内の `encoder_version='BETA'` は、機能が GA となった際に `'STABLE'` へ切り替えてください。最新状況は [Bitmovin Developer Docs](https://developer.bitmovin.com/) をご確認ください。
+  - サンプルでは最新の encoder 修正を取り込むため `encoder_version='BETA'` を指定していますが、これは AI Scene Analysis の必須要件ではありません（`'STABLE'` でも利用できます）。最新状況は [Bitmovin Developer Docs](https://developer.bitmovin.com/) をご確認ください。
   - 映像は Per-Title テンプレート（単一ストリーム）で定義しており、実際の ABR ラダーはエンコード時に Bitmovin Per-Title が自動展開します。
   - パススルー版 (`create_h264_mp4_ai_scene_analysis_passthrough_on_aws.py`) は、単一の STANDARD H.264 映像ストリーム（音声・Per-Title なし）を progressive MP4 で最小限にエンコードし、automatic ad placement と HLS/DASH マニフェスト生成は行いません。AI シーン解析結果（`ai/` 配下の JSON）の取得を主目的としたサンプルです。
 
 ## 前提条件
 
-- AI Scene Analysis に対応した Bitmovin Encoder（BETA エンコーダー）
+- AI Scene Analysis に対応した Bitmovin Encoder
 - AI Scene Analysis 関連クラスを含む Bitmovin Python SDK
 
 ## サンプルの利用方法

--- a/ai-scene-analysis/create_h264_mp4_ai_scene_analysis_passthrough_on_aws.py
+++ b/ai-scene-analysis/create_h264_mp4_ai_scene_analysis_passthrough_on_aws.py
@@ -10,8 +10,8 @@
 #
 # To produce playable HLS/DASH output, audio, automatic ad placement, or a Per-Title ladder, see the full sample.
 #
-# NOTE: AI Scene Analysis currently requires the BETA encoder version. Switch encoder_version to 'STABLE'
-# once the feature is generally available. See https://developer.bitmovin.com/ .
+# NOTE: encoder_version='BETA' is set only to pick up the latest encoder fixes; it is NOT required
+# for AI Scene Analysis ('STABLE' also works). See https://developer.bitmovin.com/ .
 
 import time
 

--- a/ai-scene-analysis/create_h264_mp4_ai_scene_analysis_passthrough_on_aws.py
+++ b/ai-scene-analysis/create_h264_mp4_ai_scene_analysis_passthrough_on_aws.py
@@ -70,7 +70,7 @@ def main():
             bucket_name=S3_OUTPUT_BUCKET_NAME,
             name='Test S3 Output'))
 
-    # === Encoding definition (BETA encoder is required for AI Scene Analysis) ===
+    # === Encoding definition (BETA picks up the latest encoder fixes; STABLE also works) ===
     encoding = bitmovin_api.encoding.encodings.create(
         encoding=Encoding(
             name=f'{TEST_ITEM}',

--- a/ai-scene-analysis/create_per_title_h264_aac_fmp4_dash_hls_with_ai_scene_analysis_on_aws.py
+++ b/ai-scene-analysis/create_per_title_h264_aac_fmp4_dash_hls_with_ai_scene_analysis_on_aws.py
@@ -75,7 +75,7 @@ def main():
             bucket_name=S3_OUTPUT_BUCKET_NAME,
             name='Test S3 Output'))
 
-    # === Encoding definition (BETA encoder is required for AI Scene Analysis) ===
+    # === Encoding definition (BETA picks up the latest encoder fixes; STABLE also works) ===
     encoding = bitmovin_api.encoding.encodings.create(
         encoding=Encoding(
             name=f'{TEST_ITEM}',

--- a/ai-scene-analysis/create_per_title_h264_aac_fmp4_dash_hls_with_ai_scene_analysis_on_aws.py
+++ b/ai-scene-analysis/create_per_title_h264_aac_fmp4_dash_hls_with_ai_scene_analysis_on_aws.py
@@ -6,8 +6,8 @@
 #   - automatic_ad_placement: SCTE cue tags inserted at scene boundaries in the manifests
 #   - output_language_codes : languages used for the AI-generated descriptions
 #
-# NOTE: AI Scene Analysis currently requires the BETA encoder version. Switch encoder_version
-# to 'STABLE' once the feature is generally available. See https://developer.bitmovin.com/ .
+# NOTE: encoder_version='BETA' is set only to pick up the latest encoder fixes; it is NOT required
+# for AI Scene Analysis ('STABLE' also works). See https://developer.bitmovin.com/ .
 
 import time
 

--- a/audio-only/README.md
+++ b/audio-only/README.md
@@ -1,0 +1,55 @@
+# はじめに
+
+このサンプルでは、Bitmovin Encoder API を使用して **音声のみ (Audio-Only)** の AAC エンコードを行い、HLS/DASH で配信する方法を説明します。映像を含まず音声トラックのみを Fragmented MP4 でエンコードし、それを参照する HLS/DASH マニフェストを生成するため、音楽配信やポッドキャスト、ラジオ的なユースケースに利用できます。本サンプルでは Python を用いた実装を示します。
+
+本サンプルディレクトリには、音声のみの AAC エンコードを行うサンプルを 1 つ含みます。
+
+1. 音声のみ (AAC) の FMP4 を HLS/DASH で配信するサンプル
+   ```text
+   create_aac_only_fmp4_hls_dash.py
+   ```
+
+- 特記事項
+  - 入力ファイルから音声トラックを `IngestInputStream` (`StreamSelectionMode.AUDIO_RELATIVE`) で取り込み、映像ストリームは作成しません。サンプルでは MP3 ファイルを入力として想定しています。
+  - 音声は AAC ステレオ (`AacChannelLayout.CL_STEREO`)、デフォルトでは 128kbps / 48kHz の 1 プロファイルのみを Fragmented MP4 形式で出力します。
+  - マニフェストはエンコード完了後に生成します。DASH では音声のみの AdaptationSet を、HLS では音声レンディション (`AudioMediaInfo`) のみを定義します（映像 variant は含みません）。
+  - クラウドリージョンは `AWS_AP_NORTHEAST_1`、encoder は `STABLE`、マニフェスト生成には `ManifestGenerator.V2` を使用します。
+
+## 前提条件
+
+- Bitmovin Encoder を利用可能な Bitmovin アカウント
+- Bitmovin Python SDK
+
+## サンプルの利用方法
+
+1. Bitmovin Encoder API Key と Organization ID を下記に設定します。
+   ```python
+   API_KEY = '<INSERT YOUR API KEY>'
+   ORG_ID = '<INSERT YOUR ORG ID>'
+   ```
+
+2. 入出力の bucket の情報および入力ファイルパスを下記に設定します。入力には音声トラックを含むファイル（サンプルでは MP3）を指定します。
+   ```python
+   S3_INPUT_ACCESS_KEY = '<INSERT_YOUR_ACCESS_KEY>'
+   S3_INPUT_SECRET_KEY = '<INSERT_YOUR_SECRET_KEY>'
+   S3_INPUT_BUCKET_NAME = '<INSERT_YOUR_BUCKET_NAME>'
+
+   AUDIO_INPUT_PATH = '/path/to/your/input/audio.mp3'
+
+   S3_OUTPUT_ACCESS_KEY = '<INSERT_YOUR_ACCESS_KEY>'
+   S3_OUTPUT_SECRET_KEY = '<INSERT_YOUR_SECRET_KEY>'
+   S3_OUTPUT_BUCKET_NAME = '<INSERT_YOUR_BUCKET_NAME>'
+   ```
+
+3. 必要に応じて、出力する音声プロファイル（ビットレート・サンプリングレート）を変更します。デフォルトでは 128kbps / 48kHz の 1 プロファイルのみを出力します。
+   ```python
+   audio_encoding_profiles = [
+       dict(bitrate=128000, rate=48_000)
+   ]
+   ```
+
+4. サンプルコードを実行し、エンコードを開始します。
+
+## 処理結果例
+
+エンコードが終了すると、音声のみの AAC 出力が Fragmented MP4 形式で生成され、それを参照する HLS/DASH マニフェストがそれぞれ生成されます。映像トラックは含まれず、音声のみの再生が可能なストリームが出力されます。

--- a/drm/README.md
+++ b/drm/README.md
@@ -1,0 +1,109 @@
+# はじめに
+
+このサンプルでは、Bitmovin Encoder API を使用して、DRM (Digital Rights Management) で暗号化した VOD ストリームをエンコードする方法を説明します。Bitmovin Encoder では、エンコードした Muxing に対して各種 DRM システム (Widevine / PlayReady / FairPlay) の暗号化を付与し、HLS / DASH / Smooth Streaming のマニフェストに content protection 情報を埋め込んだ状態で出力することができます。本サンプルでは Python を用いたサンプルを説明します。
+
+本サンプルディレクトリには複数のサンプルを含んでおり、それぞれ「コーデック (H.264 / H.265 / VP9)」「DRM システムと暗号化方式 (Widevine / PlayReady / FairPlay、CENC CTR / CBC、FairPlay AES-CBC)」「パッケージング (DASH / HLS / Smooth Streaming)」「Per-Title の有無」の組み合わせが異なります。いずれも入出力に AWS S3 を利用し、`AWS_AP_NORTHEAST_1` リージョンでエンコードします。
+
+1. H.264 + AAC を Fragmented MP4 に格納し、CBC モードの CENC で Widevine / PlayReady / FairPlay をまとめて付与するサンプル (固定 ABR ラダー、DASH/HLS)
+   ```text
+   create_h264_aac_fmp4_cenc_cbc_drm_wv_pr_fp_dash_hls_on_aws.py
+   ```
+2. Per-Title H.264 + AAC で、DASH 用に FMP4 + CENC (Widevine / PlayReady)、HLS 用に TS + FairPlay を別々に付与するサンプル
+   ```text
+   create_per_title_h264_aac_fmp4_ts_drm_wv_pr_fp_dash_hls_on_aws.py
+   ```
+3. Per-Title H.264 + AAC を Fragmented MP4 (ismv / isma) に格納し、CENC PlayReady で暗号化して Smooth Streaming で配信するサンプル
+   ```text
+   create_per_title_h264_aac_mp4_cenc_drm_pr_smooth_on_aws.py
+   ```
+4. Per-Title H.265 + AAC で、単一の FMP4 Muxing に DASH 用 CENC (Widevine / PlayReady) と HLS 用 FairPlay の 2 つの DRM を付与するサンプル
+   ```text
+   create_per_title_h265_aac_fmp4_drm_wv_pr_fp_dash_hls_on_aws.py
+   ```
+5. Per-Title VP9 (WebM) + AAC (FMP4) で、CENC Widevine のみを付与して DASH で配信するサンプル
+   ```text
+   create_per_title_vp9_aac_webm_fmp4_cenc_drm_wv_dash_on_aws.py
+   ```
+
+- 特記事項
+  - 各サンプルが扱う DRM システム・暗号化方式・パッケージング・Per-Title の有無は以下のとおりです。
+
+    | サンプル | コーデック | コンテナ | DRM システム | 暗号化方式 | パッケージング | Per-Title |
+    | --- | --- | --- | --- | --- | --- | --- |
+    | 1 | H.264 + AAC | FMP4 | Widevine / PlayReady / FairPlay | CENC (CBC, IV 16 bytes) | DASH / HLS | なし (固定 ABR ラダー) |
+    | 2 | H.264 + AAC | FMP4 (DASH) / TS (HLS) | Widevine / PlayReady (DASH)、FairPlay (HLS) | CENC (CTR, IV 8 bytes) / FairPlay AES-CBC | DASH / HLS | あり |
+    | 3 | H.264 + AAC | Fragmented MP4 (ismv / isma) | PlayReady | CENC (CTR, IV 8 bytes) | Smooth Streaming | あり |
+    | 4 | H.265 + AAC | FMP4 | Widevine / PlayReady (DASH)、FairPlay (HLS) | CENC (CTR, IV 8 bytes) / FairPlay AES-CBC | DASH / HLS | あり |
+    | 5 | VP9 (映像) + AAC (音声) | WebM (映像) / FMP4 (音声) | Widevine | CENC (CTR, IV 8 bytes) | DASH | あり |
+
+  - サンプル 1 は `CencDrm` の `encryption_mode=EncryptionMode.CBC` を指定し、1 つの CENC 設定の中に Widevine (`pssh`)・PlayReady (`la_url`)・FairPlay (`iv` / `uri`) をまとめて含めています。映像・音声の同じ FMP4 Muxing に同一の CENC 設定を適用し、DASH と HLS の両方のマニフェストから参照します。
+  - サンプル 2 は、DASH 系統 (FMP4 Muxing) に CENC (Widevine + PlayReady、CTR モード)、HLS 系統 (TS Muxing) に単独の FairPlay (AES-CBC) を付与する構成です。映像・音声それぞれについて FMP4 と TS の 2 種類の Muxing を作成します。
+  - サンプル 3 は Smooth Streaming 向けに、`Mp4Muxing` を `fragmented_mp4_muxing_manifest_type=FragmentedMp4MuxingManifestType.SMOOTH` で生成し (映像 `video.ismv` / 音声 `audio.isma`)、CENC PlayReady を付与して `stream.ism` / `stream.ismc` を生成します。
+  - サンプル 4 は、エンコードは 1 回だけ行い、生成された単一の FMP4 Muxing に対して DASH 用に CENC、HLS 用に FairPlay の 2 種類の DRM をそれぞれ別の出力パスに書き出す構成です。DASH マニフェストは CENC、HLS マニフェストは FairPlay を参照します。
+  - サンプル 5 は、映像を VP9 (WebM)、音声を AAC (FMP4) として別コンテナで出力し、いずれも CENC Widevine で暗号化して DASH マニフェストに content protection を付与します。
+  - **DRM 鍵について (重要)**: 各サンプルではコード冒頭の定数に DRM 鍵のテスト値が直書きされています。これらはサンプルを動作させるためのプレースホルダー値であり、**本番環境では必ずご自身の値に差し替えてください**。対象となる定数は以下のとおりです (サンプルにより使用するものは異なります)。
+    - `CENC_KEY` / `CENC_KID`: CENC 暗号化に用いるコンテンツ鍵と Key ID
+    - `CENC_WIDEVINE_PSSH`: Widevine の PSSH (Base64)
+    - `CENC_PLAYREADY_LA_URL`: PlayReady のライセンス取得 URL
+    - `CENC_FAIRPLAY_IV` / `CENC_FAIRPLAY_URI` (サンプル 1)、`FAIRPLAY_KEY` / `FAIRPLAY_IV` / `FAIRPLAY_URI` (サンプル 2・4): FairPlay の鍵 / IV / キー URI (`skd://...`)
+  - Per-Title を使用するサンプル (2〜5) では、映像ストリームを Per-Title テンプレート (`PER_TITLE_TEMPLATE` / `PER_TITLE_TEMPLATE_FIXED_RESOLUTION_AND_BITRATE`) として定義しており、実際の ABR ラダー (レンディション) はエンコード時に Bitmovin Per-Title が自動展開します。展開後の各レンディションで出力パスが衝突しないよう、出力パスには `{height}p_{bitrate}_{uuid}` のプレースホルダーを用いています。これらのサンプルではレンディション数がエンコード後に確定するため、マニフェストはエンコード完了後に生成しています。
+  - Per-Title を使用するサンプルの映像コーデック設定には、Hulu 推奨に準拠したチューニングを適用しています (VP9 では出力解像度に応じて `cpu_used` / `tile_columns` を切り替えています)。
+
+## 前提条件
+
+- Bitmovin Encoder アカウントと API Key
+- DRM 暗号化機能を利用可能な Bitmovin Encoder
+- 入出力に使用する AWS S3 バケット
+
+## サンプルの利用方法
+
+1. Bitmovin Encoder API Key と Organization ID を下記に設定します。
+   ```python
+   API_KEY = '<INSERT YOUR API KEY>'
+   ORG_ID = '<INSERT YOUR ORG ID>'
+   ```
+
+2. 入出力の bucket の情報および入力ファイルパスを下記に設定します。
+   ```python
+   S3_INPUT_ACCESS_KEY = '<INSERT_YOUR_ACCESS_KEY>'
+   S3_INPUT_SECRET_KEY = '<INSERT_YOUR_SECRET_KEY>'
+   S3_INPUT_BUCKET_NAME = '<INSERT_YOUR_BUCKET_NAME>'
+
+   INPUT_PATH = "{YOUR INPUT FILE PATH}"
+
+   S3_OUTPUT_ACCESS_KEY = '<INSERT_YOUR_ACCESS_KEY>'
+   S3_OUTPUT_SECRET_KEY = '<INSERT_YOUR_SECRET_KEY>'
+   S3_OUTPUT_BUCKET_NAME = '<INSERT_YOUR_BUCKET_NAME>'
+   ```
+
+3. DRM 鍵の定数をご自身の値に差し替えます。サンプルにはテスト値が直書きされているため、本番では必ず差し替えてください (使用する定数はサンプルにより異なります)。
+   ```python
+   CENC_KEY = '<INSERT YOUR CENC KEY>'
+   CENC_KID = '<INSERT YOUR CENC KID>'
+   CENC_WIDEVINE_PSSH = '<INSERT YOUR WIDEVINE PSSH>'
+   CENC_PLAYREADY_LA_URL = '<INSERT YOUR PLAYREADY LA URL>'
+   # サンプル 1: CENC に内包する FairPlay
+   CENC_FAIRPLAY_IV = '<INSERT YOUR FAIRPLAY IV>'
+   CENC_FAIRPLAY_URI = '<INSERT YOUR FAIRPLAY URI>'
+   # サンプル 2・4: 単独 FairPlay
+   FAIRPLAY_KEY = '<INSERT YOUR FAIRPLAY KEY>'
+   FAIRPLAY_IV = '<INSERT YOUR FAIRPLAY IV>'
+   FAIRPLAY_URI = '<INSERT YOUR FAIRPLAY URI>'
+   ```
+
+4. 必要に応じて、出力エンコードの Profile (ABR ラダー / Per-Title テンプレート) を変更します。Per-Title を使用するサンプルでは、`encoding_profiles_*` で定義したテンプレートをもとに実際のレンディションがエンコード時に自動展開されます。
+   ```python
+   encoding_profiles_h264_pertitle = [
+       {"height": 180, "profile": ProfileH264.BASELINE, "level": None, "mode": StreamMode.PER_TITLE_TEMPLATE, "aqs": 1.2},
+       # ...
+       {"height": 1080, "profile": ProfileH264.HIGH, "level": None, "mode": StreamMode.PER_TITLE_TEMPLATE, "aqs": 0.5},
+   ]
+   ```
+
+5. サンプルコードを実行し、エンコードを開始します。
+
+## 処理結果例
+
+エンコードが終了すると、各サンプルのコーデック・コンテナに従って DRM で暗号化された Muxing が出力先 S3 に生成され、それを参照するマニフェスト (サンプル 1・2・4 は DASH と HLS、サンプル 3 は Smooth Streaming、サンプル 5 は DASH) が出力されます。マニフェストには各 DRM システムの content protection 情報が埋め込まれます。
+
+再生テストには、対象の DRM システム (Widevine / PlayReady / FairPlay) に対応したプレイヤーと、有効なライセンスサーバーが必要です。サンプルに直書きされた DRM 鍵はテスト値のため、実際にライセンス取得を伴う再生を行う場合はご自身の鍵・ライセンスサーバー情報に差し替えてください。

--- a/drm/README.md
+++ b/drm/README.md
@@ -36,6 +36,8 @@
     | 4 | H.265 + AAC | FMP4 | Widevine / PlayReady (DASH)、FairPlay (HLS) | CENC (CTR, IV 8 bytes) / FairPlay AES-CBC | DASH / HLS | あり |
     | 5 | VP9 (映像) + AAC (音声) | WebM (映像) / FMP4 (音声) | Widevine | CENC (CTR, IV 8 bytes) | DASH | あり |
 
+    ※ サンプル 2〜5 はコード上で `encryption_mode` を明示指定しておらず、CTR は Bitmovin API のデフォルト値です（サンプル 1 のみ `EncryptionMode.CBC` を明示指定しています）。
+
   - サンプル 1 は `CencDrm` の `encryption_mode=EncryptionMode.CBC` を指定し、1 つの CENC 設定の中に Widevine (`pssh`)・PlayReady (`la_url`)・FairPlay (`iv` / `uri`) をまとめて含めています。映像・音声の同じ FMP4 Muxing に同一の CENC 設定を適用し、DASH と HLS の両方のマニフェストから参照します。
   - サンプル 2 は、DASH 系統 (FMP4 Muxing) に CENC (Widevine + PlayReady、CTR モード)、HLS 系統 (TS Muxing) に単独の FairPlay (AES-CBC) を付与する構成です。映像・音声それぞれについて FMP4 と TS の 2 種類の Muxing を作成します。
   - サンプル 3 は Smooth Streaming 向けに、`Mp4Muxing` を `fragmented_mp4_muxing_manifest_type=FragmentedMp4MuxingManifestType.SMOOTH` で生成し (映像 `video.ismv` / 音声 `audio.isma`)、CENC PlayReady を付与して `stream.ism` / `stream.ismc` を生成します。

--- a/filters/deinterlace/README.md
+++ b/filters/deinterlace/README.md
@@ -1,0 +1,75 @@
+# はじめに
+
+このサンプルでは、Bitmovin Encoder API を使用して **Deinterlace (インターレース解除) フィルター** を適用したエンコードを行う方法を説明します。インターレース素材（フィールド構造を持つ映像）を入力とし、Deinterlace フィルターで progressive へ変換しながら H.264 + AAC の Fragmented MP4 を生成し、HLS/DASH で配信します。本サンプルでは Python を用いた実装を示します。
+
+本サンプルディレクトリには、Deinterlace フィルターを適用したサンプルを 1 つ含みます。
+
+1. Deinterlace フィルター適用 H.264 + AAC (FMP4) を HLS/DASH で配信するサンプル
+   ```text
+   create_h264_aac_fmp4_hls_dash_with_deinterlace_filter.py
+   ```
+
+- 特記事項
+  - 映像ストリームに `DeinterlaceFilter` を `StreamFilter` (position=0) として適用しています。フィルターの設定は次の通りです。
+    - `parity=PictureFieldParity.AUTO`: フィールドの優先順位（パリティ）を自動判定します。
+    - `mode=DeinterlaceMode.FRAME`: フレーム単位でインターレース解除を行います。
+    - `frame_selection_mode=DeinterlaceFrameSelectionMode.ALL`: すべてのフレームを処理対象とします。
+    - `auto_enable=DeinterlaceAutoEnable.META_DATA_AND_CONTENT_BASED`: 入力のメタデータと映像内容の両方からインターレースを判定し、必要な場合のみフィルターを有効化します。
+  - 映像は H.264 (`PresetConfiguration.VOD_STANDARD`)、デフォルトでは 1080p / 2Mbps の 1 プロファイル、音声は AAC ステレオ 128kbps / 48kHz を Fragmented MP4 形式で出力します。
+  - クラウドリージョンは `CloudRegion.AUTO`、encoder は `STABLE` を使用します。
+  - マニフェスト (HLS/DASH) はエンコード開始リクエスト (`StartEncodingRequest`) に渡して `ManifestGenerator.V2` で生成します。HLS では映像 variant に audio group `audio` を紐付けます。
+
+## 前提条件
+
+- Bitmovin Encoder を利用可能な Bitmovin アカウント
+- Bitmovin Python SDK
+
+## サンプルの利用方法
+
+1. Bitmovin Encoder API Key と Organization ID を下記に設定します。
+   ```python
+   API_KEY = '<INSERT YOUR API KEY>'
+   ORG_ID = '<INSERT YOUR ORG ID>'
+   ```
+
+2. 入出力の bucket の情報および入力ファイルパスを下記に設定します。入力にはインターレース素材を指定します。
+   ```python
+   S3_INPUT_ACCESS_KEY = '<INSERT YOUR ACCESS KEY>'
+   S3_INPUT_SECRET_KEY = '<INSERT YOUR SECRET KEY>'
+   S3_INPUT_BUCKET_NAME = '<INSERT YOUR BUCKET NAME>'
+
+   INPUT_PATH = "<INSERT YOUR INPUT PATH>"
+
+   S3_OUTPUT_ACCESS_KEY = '<INSERT YOUR ACCESS KEY>'
+   S3_OUTPUT_SECRET_KEY = '<INSERT YOUR SECRET KEY>'
+   S3_OUTPUT_BUCKET_NAME = '<INSERT YOUR BUCKET NAME>'
+   ```
+
+3. 必要に応じて、出力エンコードのプロファイルを変更します。デフォルトでは映像は 1080p / 2Mbps の 1 プロファイル、音声は 128kbps / 48kHz のみを出力します。
+   ```python
+   encoding_profiles_h264 = [
+       dict(height=1080, bitrate=2_000_000, level=None, mode=StreamMode.STANDARD),
+   ]
+
+   encoding_profiles_aac = [
+       dict(bitrate=128000, rate=48_000)
+   ]
+   ```
+
+4. 必要に応じて、Deinterlace フィルターのパラメータを変更します。
+   ```python
+   deinterlace_filter = bitmovin_api.encoding.filters.deinterlace.create(
+       deinterlace_filter=DeinterlaceFilter(
+           parity=PictureFieldParity.AUTO,
+           mode=DeinterlaceMode.FRAME,
+           frame_selection_mode=DeinterlaceFrameSelectionMode.ALL,
+           auto_enable=DeinterlaceAutoEnable.META_DATA_AND_CONTENT_BASED
+       )
+   )
+   ```
+
+5. サンプルコードを実行し、エンコードを開始します。
+
+## 処理結果例
+
+エンコードが終了すると、Deinterlace フィルターで progressive 化された H.264 + AAC の出力が Fragmented MP4 形式で生成され、それを参照する HLS/DASH マニフェストがそれぞれ生成されます。インターレース素材特有のフィールドのちらつきが解消された映像が再生できます。

--- a/fixed-bitrate/README.md
+++ b/fixed-bitrate/README.md
@@ -1,0 +1,128 @@
+# はじめに
+
+このサンプルでは、Bitmovin Encoder API を使用して、固定ビットレート (fixed-bitrate) の ABR エンコードを行う方法を説明します。H.264 映像と AAC ステレオ音声を、解像度・ビットレートを明示的に指定した複数のレンディションにエンコードし、それらを参照する HLS/DASH マニフェストを生成します。Per-Title のように品質に応じてビットレートを自動最適化するのではなく、各レンディションのビットレートを固定値で指定する構成です。本サンプルでは Python を用いた実装を示します。
+
+本サンプルディレクトリには 12 個のサンプルを含んでいます。いずれも H.264 (FMP4 または MP4) + AAC ステレオの固定ビットレートエンコードという基本構成は共通で、出力先クラウド (AWS / Azure)、パッケージング (HLS のみ / HLS + DASH)、コンテナ (Fragmented MP4 / MP4)、オプション機能 (StreamCondition、サムネイル生成、SFTP 出力) の組み合わせで分かれています。目的に合わせて以下から選択してください。
+
+1. HLS のみ・Fragmented MP4 (基本構成)
+   ```text
+   create_h264_aac_fmp4_fixed_bitrate_hls_on_aws.py
+   create_h264_aac_fmp4_fixed_bitrate_hls_on_azure.py
+   ```
+2. HLS のみ・Fragmented MP4・StreamCondition 付き
+   ```text
+   create_h264_aac_fmp4_fixed_bitrate_hls_with_streamcondition_on_aws.py
+   create_h264_aac_fmp4_fixed_bitrate_hls_with_streamcondition_on_azure.py
+   ```
+3. HLS + DASH・Fragmented MP4・StreamCondition 付き
+   ```text
+   create_h264_aac_fmp4_fixed_bitrate_dash_hls_with_streamcondition_on_aws.py
+   create_h264_aac_fmp4_fixed_bitrate_dash_hls_with_streamcondition_on_azure.py
+   ```
+4. HLS + DASH・Fragmented MP4・StreamCondition + サムネイル生成付き
+   ```text
+   create_h264_aac_fmp4_fixed_bitrate_dash_hls_with_streamcondition_with_thumbnail_on_aws.py
+   create_h264_aac_fmp4_fixed_bitrate_dash_hls_with_streamcondition_with_thumbnail_on_azure.py
+   ```
+5. HLS のみ・MP4 (HLS byte-range 方式)
+   ```text
+   create_h264_aac_mp4_fixed_bitrate_hls_on_aws.py
+   create_h264_aac_mp4_fixed_bitrate_hls_on_azure.py
+   ```
+6. HLS + DASH・Fragmented MP4・SFTP 出力
+   ```text
+   create_h264_aac_fmp4_dash_hls_sftp_output_just_in_time.py
+   create_h264_aac_fmp4_dash_hls_sftp_output_post_encoding.py
+   ```
+
+上記のうち 1〜5 は、出力先クラウドの違いで AWS 版 (`_on_aws.py`、入出力ともに Amazon S3) と Azure 版 (`_on_azure.py`、入出力ともに Azure Blob Storage) の 2 ファイルがペアで用意されています。6 の SFTP 出力サンプルは、入力は S3、出力は SFTP サーバーで、マニフェスト生成のタイミングが異なる 2 種類 (just-in-time / post-encoding) を用意しています。
+
+- 特記事項
+  - 映像は 360p (300kbps) と 540p (600kbps) の 2 レンディション、音声は 128kbps/48kHz と 64kbps/44.1kHz の 2 レンディションをいずれも固定ビットレート (`StreamMode.STANDARD`) で出力します。映像コーデックには `PresetConfiguration.VOD_HIGH_QUALITY` を指定しています。なお SFTP 出力サンプル (6 番) のみ、映像 360p (300kbps) 1 本・音声 64kbps 1 本のシンプルな構成です。
+  - **StreamCondition**: 音声ストリームに `Condition(attribute="AUDIOSTREAMCOUNT", operator=GREATER_THAN, value="0")` を付与し、入力に音声トラックが 1 つ以上存在する場合のみ音声ストリームを生成する条件分岐です。音声を持たない入力でもエラーにせず処理を継続させたい場合に利用します。StreamCondition 付きサンプル (2〜4 番) で有効化しています。
+  - **サムネイル生成**: 540p の映像ストリームを対象に、`THUMBNAIL_POSITION_IN_SECONDS = [10]` で指定した再生位置 (10 秒地点) のサムネイル画像 (JPEG) を `thumbnail/` 配下に出力します。`positions` に複数の秒数を指定すれば、複数枚のサムネイルを生成できます。サムネイル付きサンプル (4 番) で有効化しています。
+  - **MP4 (HLS byte-range)**: MP4 サンプル (5 番) では `Fmp4Muxing` ではなく `Mp4Muxing` を使用し、`fragmented_mp4_muxing_manifest_type=FragmentedMp4MuxingManifestType.HLS_BYTE_RANGES`、`fragment_duration=4000` を指定しています。これにより、セグメントを多数のファイルに分割せず、レンディションごとに単一の MP4 ファイルを出力したうえで、HLS マニフェストからバイトレンジ参照で再生する構成になります。
+  - **SFTP 出力 (just-in-time / post-encoding)**: 出力先に `SftpOutput` を使用するサンプル (6 番) では、マニフェスト生成のタイミングが 2 通りあります。
+    - **just-in-time** (`..._just_in_time.py`): エンコード開始前に HLS/DASH マニフェストを定義し、`StartEncodingRequest` の `vod_hls_manifests` / `vod_dash_manifests` に渡したうえで `ManifestGenerator.V2` を指定します。エンコードと同時にマニフェストが生成されます。
+    - **post-encoding** (`..._post_encoding.py`): まず `StartEncodingRequest()` でエンコードのみを実行し、エンコード完了後にあらためて HLS/DASH マニフェストを定義し、`manifests.hls.start()` / `manifests.dash.start()` を個別に呼び出して生成します。
+  - 本サンプルでは DRM は付与していませんが、DRM ライセンスをお持ちの場合は DRM をかけることもできます。
+
+## 前提条件
+
+- Bitmovin Encoder
+
+## サンプルの利用方法
+
+1. Bitmovin Encoder API Key と Organization ID を下記に設定します。
+   ```python
+   API_KEY = '<INSERT YOUR API KEY>'
+   ORG_ID = '<INSERT YOUR ORG ID>'
+   ```
+
+2. 入出力の情報および入力ファイルパスを設定します。設定する内容はサンプルの種類によって異なります。
+
+   AWS 版サンプル (`_on_aws.py`) では、入出力ともに Amazon S3 の認証情報とバケット名を設定します。
+   ```python
+   S3_INPUT_ACCESS_KEY = '<INSERT_YOUR_ACCESS_KEY>'
+   S3_INPUT_SECRET_KEY = '<INSERT_YOUR_SECRET_KEY>'
+   S3_INPUT_BUCKET_NAME = '<INSERT_YOUR_BUCKET_NAME>'
+
+   INPUT_PATH = "sintel/Sintel.2010.1080p.mkv"
+
+   S3_OUTPUT_ACCESS_KEY = '<INSERT_YOUR_ACCESS_KEY>'
+   S3_OUTPUT_SECRET_KEY = '<INSERT_YOUR_SECRET_KEY>'
+   S3_OUTPUT_BUCKET_NAME = '<INSERT_YOUR_BUCKET_NAME>'
+   ```
+
+   Azure 版サンプル (`_on_azure.py`) では、入出力ともに Azure Blob Storage のアカウント名・アカウントキー・コンテナ名を設定します。
+   ```python
+   AZURE_INPUT_ACCOUNT_NAME = '<INSERT_YOUR_AZURE_ACCOUNT_NAME>'
+   AZURE_INPUT_ACCOUNT_KEY = '<INSERT_YOUR_AZURE_ACCOUNT_KEY>'
+   AZURE_INPUT_CONTAINER_NAME = '<INSERT_YOUR_CONTAINER_NAME>'
+
+   INPUT_PATH = "sintel/Sintel.2010.1080p.mkv"
+
+   AZURE_OUTPUT_ACCOUNT_NAME = '<INSERT_YOUR_AZURE_ACCOUNT_NAME>'
+   AZURE_OUTPUT_ACCOUNT_KEY = '<INSERT_YOUR_AZURE_ACCOUNT_KEY>'
+   AZURE_OUTPUT_CONTAINER_NAME = '<INSERT_YOUR_CONTAINER_NAME>'
+   ```
+
+   SFTP 出力サンプル (6 番) では、入力は S3、出力は SFTP サーバーのホスト名・ユーザー名・パスワード・ポート番号を設定します。
+   ```python
+   S3_INPUT_ACCESS_KEY = '<INSERT_YOUR_ACCESS_KEY>'
+   S3_INPUT_SECRET_KEY = '<INSERT_YOUR_SECRET_KEY>'
+   S3_INPUT_BUCKET_NAME = '<INSERT_YOUR_BUCKET_NAME>'
+
+   INPUT_PATH = "big_buck_bunny_1080p_h264_short.mov"
+
+   SFTP_OUTPUT_HOST_NAME = '<INSERT_YOUR_SFTP_HOST_NAME>'
+   SFTP_OUTPUT_USER_NAME = '<INSERT_YOUR_SFTP_USER_NAME>'
+   SFTP_OUTPUT_PASSWORD = '<INSERT_YOUR_SFTP_PASSWORD>'
+   SFTP_OUTPUT_PORT_NUMBER = 22
+   ```
+
+3. 必要に応じて、出力エンコードの Profile を変更します。デフォルトでは映像は 360p/540p、音声は 128kbps/64kbps を出力するよう設定されています。
+   ```python
+   encoding_profiles_h264 = [
+       dict(height=360, bitrate=300000, level=None, mode=StreamMode.STANDARD),
+       dict(height=540, bitrate=600000, level=None, mode=StreamMode.STANDARD),
+   ]
+
+   encoding_profiles_aac = [
+       dict(bitrate=128000, rate=48_000),
+       dict(bitrate=64000, rate=44_100)
+   ]
+   ```
+
+4. サムネイル付きサンプル (4 番) を使う場合は、必要に応じてサムネイルを生成する再生位置 (秒) を変更します。
+   ```python
+   THUMBNAIL_POSITION_IN_SECONDS = [10]
+   ```
+
+5. サンプルコードを実行し、エンコードを開始します。
+
+## 処理結果例
+
+エンコードが終了すると、固定ビットレートでエンコードされた H.264 + AAC の出力が生成され、それを参照する HLS (DASH 対応サンプルでは HLS と DASH の両方) マニフェストが生成されます。Fragmented MP4 サンプルではセグメント化された出力が、MP4 サンプルではレンディションごとの単一 MP4 ファイル (HLS からバイトレンジ参照) が出力されます。
+
+StreamCondition 付きサンプルでは、入力に音声トラックが存在する場合のみ音声ストリームが生成されます。サムネイル付きサンプルでは、加えて `thumbnail/` 配下にサムネイル画像が生成されます。SFTP 出力サンプルでは、指定した SFTP サーバー上に出力ファイルとマニフェストが生成されます (just-in-time 版はエンコードと同時に、post-encoding 版はエンコード完了後にマニフェストが生成されます)。

--- a/hdr10/README.md
+++ b/hdr10/README.md
@@ -1,0 +1,62 @@
+# はじめに
+
+このサンプルでは、Bitmovin Encoder API を使用して **HDR10** 出力のエンコードを **Per-Title** と組み合わせて行う方法を説明します。HDR10 のカラー情報（BT.2020 色域・SMPTE ST 2084 / PQ・10bit）とマスタリングメタデータを付与した H.265 映像を生成し、Per-Title により最適な ABR ラダーを自動展開しながら、AAC 音声とともに Fragmented MP4 で出力して HLS/DASH で配信します。本サンプルでは Python を用いた実装を示します。
+
+本サンプルディレクトリには、HDR10 + Per-Title のエンコードを行うサンプルを 1 つ含みます。
+
+1. HDR10 H.265 + AAC (FMP4) を Per-Title で HLS/DASH 配信するサンプル
+   ```text
+   create-hdr10-pertitle-encoding.py
+   ```
+
+- 特記事項
+  - 映像は H.265 (`ProfileH265.MAIN10`)、`PixelFormat.YUV420P10LE` の 10bit でエンコードし、HDR10 のために以下を設定しています。
+    - `ColorConfig`: `ColorSpace.BT2020_NCL` / `ColorPrimaries.BT2020` / `ColorTransfer.SMPTE2084`
+    - `hdr=True`、`master_display='G(13250,34500)B(7500,3000)R(34000,16000)WP(15635,16450)L(10000000,1)'`
+    - `max_content_light_level=800`、`max_picture_average_light_level=400`
+  - 映像ストリームは `StreamMode.PER_TITLE_TEMPLATE` のテンプレートとして定義し、エンコード開始リクエストで `PerTitle(h265_configuration=H265PerTitleConfiguration(auto_representations=AutoRepresentation()))` を指定して、実際の ABR ラダーを Bitmovin Per-Title が自動展開します。
+  - 音声は AAC 5.1ch (`AacChannelLayout.CL_5_1_BACK`)、128kbps / 48kHz を Fragmented MP4 形式で出力します。
+  - クラウドリージョンは `AWS_AP_NORTHEAST_1`、encoder は `STABLE` を使用します。マニフェストはエンコード完了後に生成し、HLS は `HlsVersion.HLS_V8` を使用します。
+
+## 前提条件
+
+- HDR10 (H.265 10bit) エンコードに対応した Bitmovin Encoder
+- Bitmovin Python SDK
+
+## サンプルの利用方法
+
+1. Bitmovin Encoder API Key と Organization ID を下記に設定します。
+   ```python
+   API_KEY = '<INSERT YOUR API KEY>'
+   ORG_ID = '<INSERT YOUR ORG ID>'
+   ```
+
+2. 入出力の bucket の情報および入力ファイルパスを下記に設定します。サンプルでは入力例として https://4kmedia.org/ のファイル名を記述しています。
+   ```python
+   S3_INPUT_ACCESS_KEY = '<INSERT_YOUR_ACCESS_KEY>'
+   S3_INPUT_SECRET_KEY = '<INSERT_YOUR_SECRET_KEY>'
+   S3_INPUT_BUCKET_NAME = '<INSERT_YOUR_BUCKET_NAME>'
+
+   INPUT_PATH = "hdr10/Sony Bravia OLED 4K Demo.mp4"  # from https://4kmedia.org/
+
+   S3_OUTPUT_ACCESS_KEY = '<INSERT_YOUR_ACCESS_KEY>'
+   S3_OUTPUT_SECRET_KEY = '<INSERT_YOUR_SECRET_KEY>'
+   S3_OUTPUT_BUCKET_NAME = '<INSERT_YOUR_BUCKET_NAME>'
+   ```
+
+3. 必要に応じて、Per-Title の映像プロファイルを変更します。デフォルトでは H.265 MAIN10 を `PER_TITLE_TEMPLATE` モードで定義しています。
+   ```python
+   encoding_profiles_h265_pertitle = [
+       dict(height=None, profile=ProfileH265.MAIN10, level=None, mode=StreamMode.PER_TITLE_TEMPLATE, aqs=1.2),
+   ]
+   ```
+
+4. 必要に応じて、HDR10 のマスタリングメタデータ（`master_display`・`max_content_light_level`・`max_picture_average_light_level`）を入力素材に合わせて調整します。
+
+5. サンプルコードを実行し、エンコードを開始します。
+
+## 処理結果例
+
+エンコードが終了すると、HDR10 (H.265 MAIN10 / 10bit / BT.2020 / PQ) の映像が Per-Title で複数の ABR variant に展開されて生成され、AAC 5.1ch 音声とともに Fragmented MP4 形式で出力されます。あわせて、それらを参照する HLS/DASH マニフェストがそれぞれ生成されます。
+
+再生テストには HDR10 のストリーミング再生に対応したデバイス・プレイヤーが必要になります。

--- a/keyframes/README.md
+++ b/keyframes/README.md
@@ -1,0 +1,86 @@
+# はじめに
+
+このサンプルでは、Bitmovin Encoder API を使用して、API で keyframe（キーフレーム）を明示的に指定し、その位置でセグメントを区切るエンコードを行う方法を説明します。広告挿入（ad opportunity）などの特定の時刻でセグメント境界を強制的に発生させたい場合に利用するパターンです。本サンプルでは Python を用いた実装を示します。
+
+通常、Fragmented MP4 のセグメントは `segment_length` で指定した一定間隔で区切られますが、`Keyframe` リソースを `segment_cut=True` で作成すると、指定した時刻に追加のキーフレームを挿入し、そこでセグメントを分割できます。これにより、規則的なセグメントグリッドとは別に、任意の時刻でセグメント境界を確実に発生させることができます。本サンプルでは H.264 + AAC ステレオを Fragmented MP4 で Muxing し、HLS / DASH の両マニフェストを生成します。
+
+本サンプルディレクトリには、keyframe によるセグメント分割を扱う 2 つのサンプルを含みます。両者の違いは、`segment_cut=True` で指定する keyframe の時刻が、規則的なセグメント境界（および keyframe interval）と整列するか否かにあります。
+
+1. segment aligned — keyframe 指定位置がセグメント境界と整列するサンプル
+   ```text
+   create_h264_aac_fmp4_hls_dash_with_keyframes_segment_aligned.py
+   ```
+2. segment non-aligned — keyframe 指定位置がセグメント境界と整列しないサンプル
+   ```text
+   create_h264_aac_fmp4_hls_dash_with_keyframes_segment_non_aligned.py
+   ```
+
+- 特記事項
+  - 両サンプルとも、広告挿入位置として `ad_opportunity_placements = [0.32, 19.2]`（秒）を定義し、各時刻に対して `Keyframe(time=..., segment_cut=True)` を作成しています。`segment_cut=True` により、その時刻でセグメントが区切られます。
+  - H.264 の Codec Configuration では `min_keyframe_interval` と `max_keyframe_interval` を同じ値に設定し、一定間隔でキーフレームが入る（固定 GOP の）構成にしています。
+  - segment aligned サンプルでは、`segment_length = 5.76` 秒、`key_frame_interval = 1.92` 秒（fps=25）と設定されています。`segment_length` は `key_frame_interval` の整数倍（5.76 = 1.92 × 3）であり、規則的なセグメント境界がキーフレーム間隔のグリッド上に乗るように設計されています。出力 Profile は 360p / 540p / 1080p の 3 段です。
+  - segment non-aligned サンプルでは、`segment_length = 6` 秒、`key_frame_interval = 2` 秒（fps=25）と設定されています。`ad_opportunity_placements` に指定した時刻（0.32, 19.2）は keyframe interval（2 秒）や segment length（6 秒）の整数倍ではないため、`segment_cut=True` によって挿入される分割位置が規則的なセグメントグリッドと整列しません。出力 Profile は 360p / 540p の 2 段です。
+  - いずれのサンプルも DRM は付与していません。
+  - マニフェスト生成には `ManifestGenerator.V2` を使用しています。
+
+## 前提条件
+
+- Bitmovin Encoder（`encoder_version='STABLE'` を指定）
+- Keyframe API（`encoding.encodings.keyframes`）に対応した Bitmovin Python SDK
+
+## サンプルの利用方法
+
+1. Bitmovin Encoder API Key と Organization ID を下記に設定します。
+   ```python
+   API_KEY = '<INSERT YOUR API KEY>'
+   ORG_ID = '<INSERT YOUR ORG ID>'
+   ```
+
+2. 入出力の bucket の情報および入力ファイルパスを下記に設定します。入出力ともに AWS S3 を利用します。
+   ```python
+   S3_INPUT_ACCESS_KEY = '<INSERT_YOUR_ACCESS_KEY>'
+   S3_INPUT_SECRET_KEY = '<INSERT_YOUR_SECRET_KEY>'
+   S3_INPUT_BUCKET_NAME = '<INSERT_YOUR_BUCKET_NAME>'
+
+   INPUT_PATH = "{YOUR INPUT FILE PATH}"  # 例: "big_buck_bunny_1080p_h264.mov"
+
+   S3_OUTPUT_ACCESS_KEY = '<INSERT_YOUR_ACCESS_KEY>'
+   S3_OUTPUT_SECRET_KEY = '<INSERT_YOUR_SECRET_KEY>'
+   S3_OUTPUT_BUCKET_NAME = '<INSERT_YOUR_BUCKET_NAME>'
+   ```
+
+3. 必要に応じて、セグメント長・キーフレーム間隔・フレームレート、およびセグメントを区切る位置（広告挿入位置）を変更します。下記は segment aligned サンプルの例です。
+   ```python
+   # Ad opportunity placements (expressed in seconds)
+   ad_opportunity_placements = [0.32, 19.2]
+
+   # Segment length in seconds
+   segment_length = 5.76
+
+   # Key frame interval in seconds
+   key_frame_interval = 1.92
+
+   # Frame rate
+   fps = 25
+   ```
+
+4. 必要に応じて、出力エンコードの Profile を変更します。デフォルトでは、segment aligned サンプルは 360p / 540p / 1080p、segment non-aligned サンプルは 360p / 540p の H.264 と、128kbps / 48kHz の AAC ステレオを出力するよう設定されています。
+   ```python
+   encoding_profiles_h264 = [
+       dict(height=360, bitrate=300000, level=None, mode=StreamMode.STANDARD),
+       dict(height=540, bitrate=600000, level=None, mode=StreamMode.STANDARD),
+       dict(height=1080, bitrate=1000000, level=None, mode=StreamMode.STANDARD),
+   ]
+
+   encoding_profiles_aac = [
+       dict(bitrate=128000, rate=48_000),
+   ]
+   ```
+
+5. サンプルコードを実行し、エンコードを開始します。エンコード完了後に HLS / DASH マニフェストの生成が実行されます。
+
+## 処理結果例
+
+エンコードが終了すると、H.264 + AAC の出力が Fragmented MP4 形式で生成され、それを参照する HLS / DASH マニフェスト（`stream.m3u8` / `stream.mpd`）がそれぞれ生成されます。`segment_cut=True` で指定した時刻ではセグメントが区切られるため、生成された各 media playlist / representation のセグメント境界を確認すると、指定した広告挿入位置でセグメントが分割されていることが確認できます。
+
+segment aligned サンプルでは、指定したセグメント境界がキーフレーム間隔のグリッド上に乗る構成のためセグメント長が比較的揃った出力になります。一方 segment non-aligned サンプルでは、`segment_cut` による分割位置が規則的なセグメントグリッドと整列しないため、その前後で通常より短いセグメントが発生します。

--- a/pertitle/README.md
+++ b/pertitle/README.md
@@ -1,0 +1,85 @@
+# はじめに
+
+このサンプルでは、Bitmovin Encoder API を使用して **Per-Title エンコーディング** を行う方法を説明します。Per-Title エンコーディングは、入力コンテンツの複雑さをエンコード時に解析し、タイトルごとに最適な ABR ラダー (解像度・ビットレートの組み合わせ) を自動的に決定する機能です。あらかじめ固定のラダーを用意するのではなく、Per-Title テンプレートを定義しておくことで、実際のレンディションをエンコーダーが自動展開します。本サンプルでは Python を用いたサンプルを説明します。
+
+本サンプルディレクトリには複数のサンプルを含んでおり、それぞれ「コーデック (H.264 / H.265 / VP9)」「コンテナ (FMP4 / TS / WebM)」「パッケージング (DASH / HLS)」「入力構成 (単一入力 / 音声・映像を別入力)」「SDK の記述スタイル」が異なります。いずれも入出力に AWS S3 を利用し、`AWS_AP_NORTHEAST_1` リージョンでエンコードします。
+
+1. H.264 + AAC の Per-Title サンプル群
+   ```text
+   create_per_title_encoding_h264_openapi.py
+   create_per_title_encoding_h264_separate_av_inputs.py
+   create_per_title_h264_aac_fmp4_ts_dash_hls_on_aws.py
+   ```
+2. H.265 (HEVC) + AAC の Per-Title サンプル
+   ```text
+   create_per_title_h265_aac_fmp4_dash_hls_on_aws.py
+   ```
+3. VP9 + AAC の Per-Title サンプル
+   ```text
+   create_per_title_vp9_aac_webm_fmp4_dash_on_aws.py
+   ```
+
+各サンプルの違いは以下のとおりです。
+
+- `create_per_title_encoding_h264_openapi.py` — H.264 + AAC を FMP4 (DASH 用) と TS (HLS 用) に出力する Per-Title サンプルです。`StreamInput` に `input_id` / `input_path` / `selection_mode` を直接指定する OpenAPI / 旧来スタイルの記述で実装されており、出力パスは実行時刻 (`datetime`) を含むパスを使用します。マニフェスト生成は既定のジェネレーターを使用します。
+- `create_per_title_encoding_h264_separate_av_inputs.py` — H.264 + AAC を FMP4 (DASH) と TS (HLS) に出力するサンプルですが、映像と音声を**別々の入力ファイル**から取り込みます (映像は video-only の mp4、音声は audio-only の wav を `IngestInputStream` で取得)。音声は 128kbps/48kHz と 64kbps/44.1kHz の 2 プロファイルを出力します。
+- `create_per_title_h264_aac_fmp4_ts_dash_hls_on_aws.py` — H.264 + AAC を、DASH 用に FMP4、HLS 用に TS の 2 種類の Muxing として出力する標準的な Per-Title サンプルです (単一入力、マニフェストは `ManifestGenerator.V2`)。
+- `create_per_title_h265_aac_fmp4_dash_hls_on_aws.py` — H.265 (HEVC) + AAC を FMP4 (CMAF) で出力するサンプルです。**単一の FMP4 Muxing を DASH と HLS の両方のマニフェストから参照**します。
+- `create_per_title_vp9_aac_webm_fmp4_dash_on_aws.py` — VP9 を WebM コンテナで出力し、音声は AAC を FMP4 (sidecar) として出力する DASH サンプルです。映像 (WebM) と音声 (FMP4) を別コンテナで提供します。
+
+- 特記事項
+  - すべてのサンプルで映像ストリームを Per-Title テンプレート (`PER_TITLE_TEMPLATE` / `PER_TITLE_TEMPLATE_FIXED_RESOLUTION_AND_BITRATE`) として定義しています。`encoding_profiles_*` に並ぶ各エントリはあくまでテンプレートであり、実際の ABR ラダー (レンディション) はエンコード時に Bitmovin Per-Title が自動展開します。`PER_TITLE_TEMPLATE_FIXED_RESOLUTION_AND_BITRATE` のエントリには、`min` / `max` ビットレートや複雑度に基づくビットレート選択 (`BitrateSelectionMode.COMPLEXITY_RANGE`) などの追加設定を付与しています。
+  - 展開後の各レンディションで出力パスが衝突しないよう、`{height}p_{bitrate}_{uuid}` のようなプレースホルダーを出力パスに用いています (`{uuid}` を含めることで、他のプレースホルダーが重複しても一意性が保たれます)。`create_per_title_encoding_h264_openapi.py` のみ `{height}p_{bitrate}` を使用しています。
+  - 各サンプルとも、Per-Title のレンディション数はエンコード完了後に確定するため、エンコードを実行してから (`EncodingMode.THREE_PASS`) DASH / HLS マニフェストを生成しています。マニフェスト生成時は Muxing 一覧を走査し、Per-Title テンプレートの Stream (`PER_TITLE_TEMPLATE` を含む mode) はスキップして、展開済みのレンディションのみを Representation / Variant として追加します。
+  - 映像コーデック設定には Hulu 推奨に準拠したチューニングを適用しています。H.264 / H.265 では解像度に応じて Profile や adaptive quantization strength を、VP9 では出力解像度に応じて `cpu_used` / `tile_columns` を切り替えています。
+  - 本サンプル群では DRM は付与していません。DRM 付きの Per-Title サンプルは `drm/` ディレクトリを参照してください。
+
+## 前提条件
+
+- Bitmovin Encoder アカウントと API Key
+- Per-Title エンコーディングを利用可能な Bitmovin Encoder
+- 入出力に使用する AWS S3 バケット
+- 音声・映像を別入力にするサンプル (`create_per_title_encoding_h264_separate_av_inputs.py`) では、映像のみ・音声のみのファイルをそれぞれ用意してください。
+
+## サンプルの利用方法
+
+1. Bitmovin Encoder API Key と Organization ID を下記に設定します。
+   ```python
+   API_KEY = '<INSERT YOUR API KEY>'
+   ORG_ID = '<INSERT YOUR ORG ID>'
+   ```
+
+2. 入出力の bucket の情報および入力ファイルパスを下記に設定します。
+   ```python
+   S3_INPUT_ACCESS_KEY = '<INSERT_YOUR_ACCESS_KEY>'
+   S3_INPUT_SECRET_KEY = '<INSERT_YOUR_SECRET_KEY>'
+   S3_INPUT_BUCKET_NAME = '<INSERT_YOUR_BUCKET_NAME>'
+
+   INPUT_PATH = "{YOUR INPUT FILE PATH}"
+
+   S3_OUTPUT_ACCESS_KEY = '<INSERT_YOUR_ACCESS_KEY>'
+   S3_OUTPUT_SECRET_KEY = '<INSERT_YOUR_SECRET_KEY>'
+   S3_OUTPUT_BUCKET_NAME = '<INSERT_YOUR_BUCKET_NAME>'
+   ```
+   音声・映像を別入力にするサンプルでは、単一の `INPUT_PATH` の代わりに映像用・音声用のパスをそれぞれ設定します。
+   ```python
+   VIDEO_INPUT_PATH = '/path/to/your/input/video_only.mp4'
+   AUDIO_INPUT_PATH = '/path/to/your/input/audio_only.wav'
+   ```
+
+3. 必要に応じて、Per-Title テンプレート (ABR ラダーのもとになる定義) を変更します。各エントリはテンプレートであり、実際のレンディションはエンコード時に自動展開されます。
+   ```python
+   encoding_profiles_h264_pertitle = [
+       {"height": 180, "profile": ProfileH264.BASELINE, "level": None, "mode": StreamMode.PER_TITLE_TEMPLATE, "aqs": 1.2},
+       # ...
+       {"height": 1080, "profile": ProfileH264.HIGH, "level": None, "mode": StreamMode.PER_TITLE_TEMPLATE, "aqs": 0.5},
+   ]
+   ```
+
+4. サンプルコードを実行し、エンコードを開始します。
+
+## 処理結果例
+
+エンコードが終了すると、Per-Title によって展開された各レンディションが、サンプルのコーデック・コンテナに従って出力先 S3 に生成されます (H.264 サンプルは FMP4 と TS、H.265 サンプルは FMP4、VP9 サンプルは映像が WebM・音声が FMP4)。続いて、それらを参照するマニフェストが生成されます。DASH と HLS の両方を生成するサンプル (H.264 サンプル群と H.265 サンプル) と、DASH のみを生成するサンプル (VP9 サンプル) があります。
+
+H.265 サンプルでは単一の FMP4 Muxing を DASH と HLS の双方から参照し、VP9 サンプルでは WebM の映像レンディションと FMP4 の音声を組み合わせて DASH を構成します。生成されたマニフェスト (`stream.mpd` / `stream.m3u8`) をプレイヤーで再生することで、Per-Title により最適化された ABR ストリーミングを確認できます。

--- a/webvtt/README.md
+++ b/webvtt/README.md
@@ -1,0 +1,92 @@
+# はじめに
+
+このサンプルでは、Bitmovin Encoder API を使用して、WebVTT 字幕付きの HLS ストリームをエンコードする方法を説明します。映像（H.264）・音声（AAC ステレオ）のエンコードに加えて、入力として渡した WebVTT ファイル（`.vtt`）を字幕トラックとして取り込み、HLS マニフェストに字幕（Subtitles）メディアとして関連付けます。本サンプルでは Python を用いた実装を示します。
+
+字幕は入力 bucket 上の WebVTT ファイルを `FileInputStream`（`file_type=FileInputStreamType.WEBVTT`）として取り込み、`WebVttConfiguration` と `ChunkedTextMuxing` を用いてセグメント化された WebVTT として出力します。HLS マニフェストでは `SubtitlesMediaInfo` を用いて字幕を `SUBTITLE` グループに登録します。
+
+本サンプルディレクトリには 4 つのサンプルを含みます。サンプルの軸は、出力コンテナ（Fragmented MP4 / MP4）と出力先クラウド（AWS / Azure）の組み合わせです。
+
+1. Fragmented MP4 で出力するサンプル
+   ```text
+   create_h264_aac_fmp4_fixed_bitrate_hls_vtt_on_aws.py
+   create_h264_aac_fmp4_fixed_bitrate_hls_vtt_on_azure.py
+   ```
+2. MP4（HLS byte-range）で出力するサンプル
+   ```text
+   create_h264_aac_mp4_fixed_bitrate_hls_vtt_on_aws.py
+   create_h264_aac_mp4_fixed_bitrate_hls_vtt_on_azure.py
+   ```
+
+- 特記事項
+  - 字幕は新規生成ではなく、入力として用意済みの WebVTT ファイル（サンプルでは `sintel/subtitles_en.vtt`、言語 `en`）を取り込んでいます。映像・音声と同じ入力 bucket 上に配置されている前提です。
+  - 字幕の Muxing には `ChunkedTextMuxing`（`segment_length=10.0`、セグメント命名 `en_webvtt_seg_%number%.vtt`）を使用し、HLS マニフェストには `SubtitlesMediaInfo`（`group_id="SUBTITLE"`、`uri="subtitles_en.m3u8"`）として登録しています。
+  - 映像は固定ビットレート（fixed bitrate）の H.264 で、`PresetConfiguration.VOD_HIGH_QUALITY` を使用し、360p / 540p の 2 段を出力します。音声は AAC ステレオで 128kbps / 48kHz と 64kbps / 44.1kHz の 2 段を出力します。
+  - コンテナによる違い:
+    - FMP4 版は `Fmp4Muxing`（`segment_length=6`、`segment_%number%.m4s`）でセグメント化された Fragmented MP4 を出力します。
+    - MP4 版は `Mp4Muxing` で単一ファイルの MP4 を出力し、`fragmented_mp4_muxing_manifest_type=FragmentedMp4MuxingManifestType.HLS_BYTE_RANGES`、`fragment_duration=4000`(ms) を指定することで、HLS から byte-range で参照できる形で配信します。
+  - 本サンプルは HLS マニフェストのみを生成します（DASH は生成しません）。マニフェストはエンコード開始時に `StartEncodingRequest(vod_hls_manifests=..., manifest_generator=ManifestGenerator.V2)` でエンコードと同時に生成されます。
+  - HLS のバージョンは `HLS_V4` を指定しています。
+  - いずれのサンプルも DRM は付与していません。
+  - クラウドによる違いは入出力ストレージ（AWS は S3、Azure は Blob Storage）と `cloud_region`（AWS は `AWS_AP_NORTHEAST_1`、Azure は `AZURE_JAPAN_EAST`）です。
+
+## 前提条件
+
+- Bitmovin Encoder（`encoder_version='STABLE'` を指定）
+- WebVTT / ChunkedTextMuxing に対応した Bitmovin Python SDK
+
+## サンプルの利用方法
+
+1. Bitmovin Encoder API Key と Organization ID を下記に設定します。
+   ```python
+   API_KEY = '<INSERT YOUR API KEY>'
+   ORG_ID = '<INSERT YOUR ORG ID>'
+   ```
+
+2. 入出力ストレージの情報および入力ファイルパスを設定します。利用するクラウドに応じて設定項目が異なります。
+
+   AWS（S3）を利用するサンプルの場合:
+   ```python
+   S3_INPUT_ACCESS_KEY = '<INSERT_YOUR_ACCESS_KEY>'
+   S3_INPUT_SECRET_KEY = '<INSERT_YOUR_SECRET_KEY>'
+   S3_INPUT_BUCKET_NAME = '<INSERT_YOUR_BUCKET_NAME>'
+
+   S3_OUTPUT_ACCESS_KEY = '<INSERT_YOUR_ACCESS_KEY>'
+   S3_OUTPUT_SECRET_KEY = '<INSERT_YOUR_SECRET_KEY>'
+   S3_OUTPUT_BUCKET_NAME = '<INSERT_YOUR_BUCKET_NAME>'
+   ```
+
+   Azure（Blob Storage）を利用するサンプルの場合:
+   ```python
+   AZURE_INPUT_ACCOUNT_NAME = '<INSERT_YOUR_AZURE_ACCOUNT_NAME>'
+   AZURE_INPUT_ACCOUNT_KEY = '<INSERT_YOUR_AZURE_ACCOUNT_KEY>'
+   AZURE_INPUT_CONTAINER_NAME = '<INSERT_YOUR_CONTAINER_NAME>'
+
+   AZURE_OUTPUT_ACCOUNT_NAME = '<INSERT_YOUR_AZURE_ACCOUNT_NAME>'
+   AZURE_OUTPUT_ACCOUNT_KEY = '<INSERT_YOUR_AZURE_ACCOUNT_KEY>'
+   AZURE_OUTPUT_CONTAINER_NAME = '<INSERT_YOUR_CONTAINER_NAME>'
+   ```
+
+3. 入力となる映像ファイルと WebVTT 字幕ファイルのパスを設定します。サンプルでは Sintel の映像と英語字幕を指定しています。
+   ```python
+   INPUT_PATH = "sintel/Sintel.2010.1080p.mkv"
+   INPUT_VTT_PATH = "sintel/subtitles_en.vtt"
+   ```
+
+4. 必要に応じて、出力エンコードの Profile を変更します。デフォルトでは 360p / 540p の H.264 と、128kbps / 48kHz・64kbps / 44.1kHz の AAC ステレオを出力するよう設定されています。
+   ```python
+   encoding_profiles_h264 = [
+       dict(height=360, bitrate=300000, level=None, mode=StreamMode.STANDARD),
+       dict(height=540, bitrate=600000, level=None, mode=StreamMode.STANDARD),
+   ]
+
+   encoding_profiles_aac = [
+       dict(bitrate=128000, rate=48_000),
+       dict(bitrate=64000, rate=44_100)
+   ]
+   ```
+
+5. サンプルコードを実行し、エンコードを開始します。エンコードの開始と同時に HLS マニフェストの生成が実行されます。
+
+## 処理結果例
+
+エンコードが終了すると、H.264 + AAC の出力（FMP4 版は Fragmented MP4、MP4 版は HLS byte-range 用の MP4）が生成され、それを参照する HLS マニフェスト（`stream.m3u8`）が生成されます。マニフェストには映像・音声に加えて、`SUBTITLE` グループの WebVTT 字幕（`subtitles_en.m3u8`、言語 `en`）が含まれ、対応プレイヤーで字幕表示を切り替えて再生できます。


### PR DESCRIPTION
## Summary

リポジトリ全体の README を整備しました。

### 各サンプルディレクトリへの README 追加（8件）
README が無かった以下のディレクトリに、既存テンプレート（`dolby` / `ai-scene-analysis`）に合わせた `README.md` を追加しました。各サンプルのコードに基づき、概要・前提条件・設定手順（認証情報はプレースホルダ）・処理結果例を記載しています。

- `audio-only` / `drm` / `filters/deinterlace` / `fixed-bitrate` / `hdr10` / `keyframes` / `pertitle` / `webvtt`

### ルート README カタログの補完
未掲載だった `audio-only` / `fixed-bitrate` / `webvtt` / `filters/deinterlace` をサンプル一覧に追加しました。

### AISA encoder-version 注記の訂正
`encoder_version='BETA'` は最新の encoder 修正を取り込むための指定であり、AI Scene Analysis の必須要件ではない旨に訂正しました（`'STABLE'` でも利用可）。AISA 2サンプルのコメントと `ai-scene-analysis/README.md` を修正しています。

## 補足
- 認証情報は全 README でプレースホルダ。実認証情報入りの `test_*.py` は `.gitignore` 済みで対象外です。
- 各 README はサンプルコードを読んで起草し、内容をレビュー済みです（DRM 鍵などの扱いも含む）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
